### PR TITLE
rm prefix from entry path

### DIFF
--- a/src/squiz_box/box/package.d
+++ b/src/squiz_box/box/package.d
@@ -25,7 +25,7 @@ interface BoxAlgo
 
     /// ditto
     ByteRange box(I)(I entries, size_t chunkSize = defaultChunkSize)
-    if (isBoxEntryRange!I && !is(I == BoxEntryRange))
+            if (isBoxEntryRange!I && !is(I == BoxEntryRange))
     {
         return box(inputRangeObject(entries), chunkSize);
     }
@@ -34,8 +34,7 @@ interface BoxAlgo
     UnboxEntryRange unbox(ByteRange bytes);
 
     /// ditto
-    UnboxEntryRange unbox(I)(I bytes)
-    if (isByteRange!I && !is(I == ByteRange))
+    UnboxEntryRange unbox(I)(I bytes) if (isByteRange!I && !is(I == ByteRange))
     {
         return unbox(inputRangeObject(bytes));
     }
@@ -53,7 +52,8 @@ interface BoxAlgo
             {
                 return new TarXzAlgo();
             }
-            else {
+            else
+            {
                 assert(false, "Squiz-Box built without LZMA support");
             }
         }
@@ -71,7 +71,8 @@ interface BoxAlgo
             {
                 return new TarBzip2Algo();
             }
-            else {
+            else
+            {
                 assert(false, "Squiz-Box built without Bzip2 support");
             }
         }
@@ -136,6 +137,7 @@ interface ArchiveEntry
     /// The archive mode this entry is for.
     /// The path of the entry within the archive.
     /// Should always be a relative path, and never go backward (..)
+    /// The directory separations are always '/' (forward slash) even on Windows
     @property string path();
 
     /// The type of entry (directory, file, symlink)
@@ -254,7 +256,7 @@ interface UnboxEntry : ArchiveEntry
 
         string entryPath = this.path;
 
-        if(removePrefix)
+        if (removePrefix)
         {
             enforce(
                 entryPath.startsWith(removePrefix),
@@ -333,7 +335,7 @@ interface UnboxEntry : ArchiveEntry
 BoxEntry fileEntry(string filename, string archiveBase, string prefix = null)
 {
     import std.path : absolutePath, buildNormalizedPath, relativePath;
-    import std.string : startsWith;
+    import std.string : replace, startsWith;
 
     const fn = buildNormalizedPath(absolutePath(filename));
     const ab = buildNormalizedPath(absolutePath(archiveBase));
@@ -343,6 +345,9 @@ BoxEntry fileEntry(string filename, string archiveBase, string prefix = null)
     auto pathInArchive = relativePath(fn, ab);
     if (prefix)
         pathInArchive = prefix ~ pathInArchive;
+
+    version (Windows)
+        pathInArchive = pathInArchive.replace('\\', '/');
 
     return new FileBoxEntry(filename, pathInArchive);
 }

--- a/src/squiz_box/box/tar.d
+++ b/src/squiz_box/box/tar.d
@@ -8,6 +8,7 @@ import std.datetime.systime;
 import std.exception;
 import std.path;
 import std.range;
+import std.string;
 
 /// BoxAlgo for ".tar" files
 class TarAlgo : BoxAlgo
@@ -364,6 +365,9 @@ private struct TarUnbox
             info.ownerId = parseOctalString(th.uid);
             info.groupId = parseOctalString(th.gid);
         }
+
+        version(Windows)
+            info.path = info.path.replace('\\', '/');
 
         _entry = new TarUnboxEntry(_input, info);
 

--- a/src/squiz_box/box/zip.d
+++ b/src/squiz_box/box/zip.d
@@ -9,6 +9,7 @@ import std.exception;
 import std.traits : isIntegral;
 import std.range;
 import std.stdio : File;
+import std.string;
 
 /// BoxAlgo for ".zip" files
 class ZipAlgo : BoxAlgo
@@ -130,13 +131,6 @@ private struct ZipBox(I)
         currentDeflated = deflater.deflated;
 
         string path = entry.path;
-
-        version (Windows)
-        {
-            import std.string : replace;
-
-            path = replace(path, '\\', '/');
-        }
 
         ushort extractVersion = 20;
         bool zip64;
@@ -734,6 +728,9 @@ private struct ZipUnbox(C) if (is(C : Cursor))
         }
 
         nextHeader = input.pos + info.compressedSize;
+
+        version (Windows)
+            info.path = info.path.replace('\\', '/');
 
         currentEntry = new ZipUnboxEntry!C(input, info);
     }

--- a/src/squiz_box/box/zip.d
+++ b/src/squiz_box/box/zip.d
@@ -1242,7 +1242,7 @@ private class InflateByChunk(C) : ZipByChunk if (is(C : Cursor))
             enforce(compressedSz == 0, "Inflate ended before end of input");
             enforce(
                 calculatedCrc32 == expectedCrc32,
-                format!"calculated = 0x%08x / expected = 0x%08x"(calculatedCrc32, expectedCrc32)
+                "CRC32 verification failed. Archive is may be corrupted",
             );
             algo.end(stream);
         }

--- a/test/archive.d
+++ b/test/archive.d
@@ -419,12 +419,15 @@ unittest
     auto dir = buildPath(tempDir(), "squiz-box-0.2.1");
 
     download(url, file);
-    scope (exit)
-        remove(file);
-
     mkdirRecurse(dir);
-    scope (exit)
-        rmdirRecurse(dir);
+
+    version (Posix)
+    {
+        scope (exit)
+            remove(file);
+        scope (exit)
+            rmdirRecurse(dir);
+    }
 
     unboxZip(File(file, "rb"))
         .each!(e => e.extractTo(dir, "squiz-box-0.2.1/"));

--- a/test/archive.d
+++ b/test/archive.d
@@ -427,7 +427,7 @@ unittest
         rmdirRecurse(dir);
 
     unboxZip(File(file, "rb"))
-        .each!(e => e.extractTo(dir));
+        .each!(e => e.extractTo(dir, "squiz-box-0.2.1/"));
 
-    assert(isFile(buildPath(dir, "squiz-box-0.2.1", "meson.build")));
+    assert(isFile(buildPath(dir, "meson.build")));
 }


### PR DESCRIPTION
Useful when archive is packed with a directory root.
Such archives may have directories entries, in which case the root directory will have an empty path.
This is handled gracefully by `extractTo`